### PR TITLE
createStream predicted address verification overload

### DIFF
--- a/src/StreamFactory.sol
+++ b/src/StreamFactory.sol
@@ -90,7 +90,7 @@ contract StreamFactory {
         address tokenAddress,
         uint256 startTime,
         uint256 stopTime
-    ) public returns (address) {
+    ) external returns (address) {
         return createStream(
             msg.sender, recipient, tokenAmount, tokenAddress, startTime, stopTime, 0
         );
@@ -114,7 +114,7 @@ contract StreamFactory {
         address tokenAddress,
         uint256 startTime,
         uint256 stopTime
-    ) public returns (address stream) {
+    ) external returns (address stream) {
         stream =
             createStream(msg.sender, recipient, tokenAmount, tokenAddress, startTime, stopTime, 0);
         IERC20(tokenAddress).safeTransferFrom(msg.sender, stream, tokenAmount);
@@ -137,14 +137,14 @@ contract StreamFactory {
         address tokenAddress,
         uint256 startTime,
         uint256 stopTime
-    ) public returns (address) {
+    ) external returns (address) {
         return createStream(payer, recipient, tokenAmount, tokenAddress, startTime, stopTime, 0);
     }
 
     /**
      * @notice Create a new stream contract instance, and verify the new stream address matches expectations from
      * using `predictStreamAddress`.
-     * @param payer the account responsible for funding the stream.
+     * The payer is assumed to be `msg.sender`.
      * @param recipient the recipient of the stream.
      * @param tokenAmount the total token amount payer is streaming to recipient.
      * @param tokenAddress the contract address of the payment token.
@@ -154,15 +154,15 @@ contract StreamFactory {
      * @return stream the address of the new stream contract.
      */
     function createStream(
-        address payer,
         address recipient,
         uint256 tokenAmount,
         address tokenAddress,
         uint256 startTime,
         uint256 stopTime,
         address predictedStreamAddress
-    ) public returns (address stream) {
-        stream = createStream(payer, recipient, tokenAmount, tokenAddress, startTime, stopTime, 0);
+    ) external returns (address stream) {
+        stream =
+            createStream(msg.sender, recipient, tokenAmount, tokenAddress, startTime, stopTime, 0);
         if (stream != predictedStreamAddress) revert UnexpectedStreamAddress();
     }
 
@@ -236,7 +236,7 @@ contract StreamFactory {
         address tokenAddress,
         uint256 startTime,
         uint256 stopTime
-    ) public view returns (address) {
+    ) external view returns (address) {
         return predictStreamAddress(
             msgSender, payer, recipient, tokenAmount, tokenAddress, startTime, stopTime, 0
         );

--- a/src/StreamFactory.sol
+++ b/src/StreamFactory.sol
@@ -32,6 +32,7 @@ contract StreamFactory {
     error TokenAmountIsZero();
     error DurationMustBePositive();
     error TokenAmountLessThanDuration();
+    error UnexpectedStreamAddress();
 
     /**
      * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
@@ -138,6 +139,31 @@ contract StreamFactory {
         uint256 stopTime
     ) public returns (address) {
         return createStream(payer, recipient, tokenAmount, tokenAddress, startTime, stopTime, 0);
+    }
+
+    /**
+     * @notice Create a new stream contract instance, and verify the new stream address matches expectations from
+     * using `predictStreamAddress`.
+     * @param payer the account responsible for funding the stream.
+     * @param recipient the recipient of the stream.
+     * @param tokenAmount the total token amount payer is streaming to recipient.
+     * @param tokenAddress the contract address of the payment token.
+     * @param startTime the unix timestamp for when the stream starts.
+     * @param stopTime the unix timestamp for when the stream ends.
+     * @param predictedStreamAddress the expected stream address the user got from calling the predict function.
+     * @return stream the address of the new stream contract.
+     */
+    function createStream(
+        address payer,
+        address recipient,
+        uint256 tokenAmount,
+        address tokenAddress,
+        uint256 startTime,
+        uint256 stopTime,
+        address predictedStreamAddress
+    ) public returns (address stream) {
+        stream = createStream(payer, recipient, tokenAmount, tokenAddress, startTime, stopTime, 0);
+        if (stream != predictedStreamAddress) revert UnexpectedStreamAddress();
     }
 
     /**

--- a/test/StreamFactory.t.sol
+++ b/test/StreamFactory.t.sol
@@ -254,6 +254,36 @@ contract StreamFactoryTest is Test {
             )
         );
     }
+
+    function test_createStream_revertsWhenStreamAddressDoesntMatchExpectedAddress() public {
+        uint256 startTime = block.timestamp;
+        uint256 stopTime = startTime + 1000;
+        uint256 tokenAmount = 1000;
+        address predictedAddress = factory.predictStreamAddress(
+            address(this), payer, recipient, tokenAmount, address(token), startTime, stopTime, 0
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(StreamFactory.UnexpectedStreamAddress.selector));
+        // changing stopTime to result in a different address
+        factory.createStream(
+            payer, recipient, tokenAmount, address(token), startTime, stopTime - 1, predictedAddress
+        );
+    }
+
+    function test_createStream_worksWhenStreamAddressMatchesExpectedAddress() public {
+        uint256 startTime = block.timestamp;
+        uint256 stopTime = startTime + 1000;
+        uint256 tokenAmount = 1000;
+        address predictedAddress = factory.predictStreamAddress(
+            address(this), payer, recipient, tokenAmount, address(token), startTime, stopTime, 0
+        );
+
+        address streamAddress = factory.createStream(
+            payer, recipient, tokenAmount, address(token), startTime, stopTime, predictedAddress
+        );
+
+        assertEq(predictedAddress, streamAddress);
+    }
 }
 
 contract StreamFactoryCreatesCorrectStreamTest is Test {

--- a/test/StreamFactory.t.sol
+++ b/test/StreamFactory.t.sol
@@ -260,13 +260,20 @@ contract StreamFactoryTest is Test {
         uint256 stopTime = startTime + 1000;
         uint256 tokenAmount = 1000;
         address predictedAddress = factory.predictStreamAddress(
-            address(this), payer, recipient, tokenAmount, address(token), startTime, stopTime, 0
+            address(this),
+            address(this),
+            recipient,
+            tokenAmount,
+            address(token),
+            startTime,
+            stopTime,
+            0
         );
 
         vm.expectRevert(abi.encodeWithSelector(StreamFactory.UnexpectedStreamAddress.selector));
         // changing stopTime to result in a different address
         factory.createStream(
-            payer, recipient, tokenAmount, address(token), startTime, stopTime - 1, predictedAddress
+            recipient, tokenAmount, address(token), startTime, stopTime - 1, predictedAddress
         );
     }
 
@@ -275,11 +282,18 @@ contract StreamFactoryTest is Test {
         uint256 stopTime = startTime + 1000;
         uint256 tokenAmount = 1000;
         address predictedAddress = factory.predictStreamAddress(
-            address(this), payer, recipient, tokenAmount, address(token), startTime, stopTime, 0
+            address(this),
+            address(this),
+            recipient,
+            tokenAmount,
+            address(token),
+            startTime,
+            stopTime,
+            0
         );
 
         address streamAddress = factory.createStream(
-            payer, recipient, tokenAmount, address(token), startTime, stopTime, predictedAddress
+            recipient, tokenAmount, address(token), startTime, stopTime, predictedAddress
         );
 
         assertEq(predictedAddress, streamAddress);


### PR DESCRIPTION
makes sure the user's predicted address matches the newly created stream.