### PR TITLE
factory: allow very low rate per second

### DIFF
--- a/src/StreamFactory.sol
+++ b/src/StreamFactory.sol
@@ -31,7 +31,6 @@ contract StreamFactory {
     error RecipientIsAddressZero();
     error TokenAmountIsZero();
     error DurationMustBePositive();
-    error TokenAmountLessThanDuration();
     error UnexpectedStreamAddress();
 
     /**
@@ -197,7 +196,6 @@ contract StreamFactory {
         if (recipient == address(0)) revert RecipientIsAddressZero();
         if (tokenAmount == 0) revert TokenAmountIsZero();
         if (stopTime <= startTime) revert DurationMustBePositive();
-        if (tokenAmount < stopTime - startTime) revert TokenAmountLessThanDuration();
 
         stream = streamImplementation.cloneDeterministic(
             encodeData(payer, recipient, tokenAmount, tokenAddress, startTime, stopTime),

--- a/test/StreamFactory.t.sol
+++ b/test/StreamFactory.t.sol
@@ -343,11 +343,6 @@ contract StreamFactoryCreatesCorrectStreamTest is Test {
         factory.createStream(payer, recipient, STREAM_AMOUNT, address(token), startTime, startTime);
     }
 
-    function test_createStream_revertsWhenAmountLessThanDuration() public {
-        vm.expectRevert(abi.encodeWithSelector(StreamFactory.TokenAmountLessThanDuration.selector));
-        factory.createStream(payer, recipient, DURATION - 1, address(token), startTime, stopTime);
-    }
-
     function test_createStream_savesStreamParameters() public {
         Stream s = Stream(
             factory.createStream(


### PR DESCRIPTION
the restriction we're removing here is unnecessary and not compatible with high value tokens, e.g. WBTC