### PR TITLE
Prerelease improvements

### DIFF
--- a/src/Stream.sol
+++ b/src/Stream.sol
@@ -200,7 +200,7 @@ contract Stream is IStream, Clone {
      * Only this stream's payer or recipient can call this function.
      * @param amount the amount of tokens to withdraw.
      */
-    function withdraw(uint256 amount) external onlyPayerOrRecipient {
+    function withdraw(uint256 amount) public onlyPayerOrRecipient {
         if (amount == 0) revert CantWithdrawZero();
         address recipient_ = recipient();
 
@@ -250,7 +250,7 @@ contract Stream is IStream, Clone {
      * Only this stream's payer or recipient can call this function.
      * @param amount the amount of tokens to withdraw.
      */
-    function withdrawAfterCancel(uint256 amount) external onlyPayerOrRecipient {
+    function withdrawAfterCancel(uint256 amount) public onlyPayerOrRecipient {
         if (amount == 0) revert CantWithdrawZero();
         address recipient_ = recipient();
 
@@ -259,6 +259,14 @@ contract Stream is IStream, Clone {
         token().safeTransfer(recipient_, amount);
 
         emit TokensWithdrawn(msg.sender, recipient_, amount);
+    }
+
+    function withdrawAvailableBalance(uint256 amount) external {
+        if (recipientCancelBalance > 0) {
+            withdrawAfterCancel(amount);
+        } else {
+            withdraw(amount);
+        }
     }
 
     /**
@@ -395,6 +403,16 @@ contract Stream is IStream, Clone {
         }
 
         return balance;
+    }
+
+    function recipientAvailableBalance() external view returns (uint256) {
+        uint256 recipientCancelBalance_ = recipientCancelBalance;
+
+        if (recipientCancelBalance_ > 0) {
+            return recipientCancelBalance_;
+        } else {
+            return recipientBalance();
+        }
     }
 
     /**

--- a/src/Stream.sol
+++ b/src/Stream.sol
@@ -309,10 +309,11 @@ contract Stream is IStream, Clone {
      * @return tokensToWithdraw the amount of tokens withdrawn
      */
     function recoverTokens(address to) external returns (uint256 tokensToWithdraw) {
+        uint256 tokenBalance_ = tokenBalance();
         uint256 requiredBalanceAfter =
-            Math.min(tokenBalance(), Math.max(remainingBalance, recipientCancelBalance));
+            Math.min(tokenBalance_, Math.max(remainingBalance, recipientCancelBalance));
 
-        tokensToWithdraw = tokenBalance() - requiredBalanceAfter;
+        tokensToWithdraw = tokenBalance_ - requiredBalanceAfter;
 
         recoverTokens(address(token()), tokensToWithdraw, to);
     }

--- a/src/Stream.sol
+++ b/src/Stream.sol
@@ -261,6 +261,11 @@ contract Stream is IStream, Clone {
         emit TokensWithdrawn(msg.sender, recipient_, amount);
     }
 
+    /**
+     * @notice Withdraw tokens to recipients's account. Works for both active and cancelled streams.
+     * @param amount the amount of tokens to withdraw
+     * @dev reverts if msg.sender is not the payer or the recipient
+     */
     function withdrawAvailableBalance(uint256 amount) external {
         if (recipientCancelBalance > 0) {
             withdrawAfterCancel(amount);
@@ -405,6 +410,9 @@ contract Stream is IStream, Clone {
         return balance;
     }
 
+    /**
+     * Returns the recipient balance. Works for both active and cancelled streams.
+     */
     function recipientAvailableBalance() external view returns (uint256) {
         uint256 recipientCancelBalance_ = recipientCancelBalance;
 

--- a/src/Stream.sol
+++ b/src/Stream.sol
@@ -200,11 +200,11 @@ contract Stream is IStream, Clone {
      * Only this stream's payer or recipient can call this function.
      * @param amount the amount of tokens to withdraw.
      */
-    function withdraw(uint256 amount) public onlyPayerOrRecipient {
+    function withdrawFromActiveBalance(uint256 amount) public onlyPayerOrRecipient {
         if (amount == 0) revert CantWithdrawZero();
         address recipient_ = recipient();
 
-        uint256 balance = recipientBalance();
+        uint256 balance = recipientActiveBalance();
         if (balance < amount) revert AmountExceedsBalance();
 
         // This is safe because it should always be the case that:
@@ -231,17 +231,17 @@ contract Stream is IStream, Clone {
 
         if (remainingBalance == 0) revert StreamNotActive();
 
-        uint256 recipientBalance_ = recipientBalance();
+        uint256 recipientActiveBalance_ = recipientActiveBalance();
 
         // This token amount is available to recipient to withdraw via `withdrawAfterCancel`.
-        recipientCancelBalance = recipientBalance_;
+        recipientCancelBalance = recipientActiveBalance_;
 
         // This zeroing is important because without it, it's possible for recipient to obtain additional funds
         // from this contract if anyone (e.g. payer) sends it tokens after cancellation.
         // Thanks to this state update, `balanceOf(recipient_)` will only return zero in future calls.
         remainingBalance = 0;
 
-        emit StreamCancelled(msg.sender, payer_, recipient_, recipientBalance_);
+        emit StreamCancelled(msg.sender, payer_, recipient_, recipientActiveBalance_);
     }
 
     /**
@@ -266,11 +266,11 @@ contract Stream is IStream, Clone {
      * @param amount the amount of tokens to withdraw
      * @dev reverts if msg.sender is not the payer or the recipient
      */
-    function withdrawAvailableBalance(uint256 amount) external {
+    function withdraw(uint256 amount) external {
         if (recipientCancelBalance > 0) {
             withdrawAfterCancel(amount);
         } else {
-            withdraw(amount);
+            withdrawFromActiveBalance(amount);
         }
     }
 
@@ -366,7 +366,7 @@ contract Stream is IStream, Clone {
      * When a stream is cancelled this function always returns zero, to make sure that `withdraw` no longer sends any funds.
      * To learn the recipient's balance post-cancel use `recipientCancelBalance`.
      */
-    function recipientBalance() public view returns (uint256) {
+    function recipientActiveBalance() public view returns (uint256) {
         uint256 startTime_ = startTime();
         uint256 stopTime_ = stopTime();
         uint256 blockTime = block.timestamp;
@@ -413,13 +413,13 @@ contract Stream is IStream, Clone {
     /**
      * Returns the recipient balance. Works for both active and cancelled streams.
      */
-    function recipientAvailableBalance() external view returns (uint256) {
+    function recipientBalance() external view returns (uint256) {
         uint256 recipientCancelBalance_ = recipientCancelBalance;
 
         if (recipientCancelBalance_ > 0) {
             return recipientCancelBalance_;
         } else {
-            return recipientBalance();
+            return recipientActiveBalance();
         }
     }
 

--- a/subgraph/abis/Stream.json
+++ b/subgraph/abis/Stream.json
@@ -115,6 +115,12 @@
         "internalType": "uint256",
         "name": "amount",
         "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
       }
     ],
     "name": "TokensRecovered",
@@ -213,6 +219,19 @@
   },
   {
     "inputs": [],
+    "name": "recipientAvailableBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "recipientBalance",
     "outputs": [
       {
@@ -241,6 +260,25 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "recoverTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokensToWithdraw",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "tokenAddress",
         "type": "address"
       },
@@ -248,6 +286,11 @@
         "internalType": "uint256",
         "name": "amount",
         "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
       }
     ],
     "name": "recoverTokens",
@@ -378,6 +421,19 @@
       }
     ],
     "name": "withdrawAfterCancel",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdrawAvailableBalance",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -82,6 +82,9 @@ type TokenRecovery @entity(immutable: true) {
 
   "The token amount."
   amount: BigInt!
+
+  "The address the tokens were sent to"
+  sentTo: Bytes!
 }
 
 type ETHRescue @entity(immutable: true) {

--- a/subgraph/src/Stream.ts
+++ b/subgraph/src/Stream.ts
@@ -31,6 +31,7 @@ export function handleTokensRecovered(event: TokensRecovered): void {
   tokenRecovery.stream = event.address;
   tokenRecovery.tokenAddress = event.params.tokenAddress;
   tokenRecovery.amount = event.params.amount;
+  tokenRecovery.sentTo = event.params.to;
 
   tokenRecovery.save();
 }

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -44,7 +44,7 @@ templates:
         - event: StreamCancelled(indexed address,indexed address,indexed
             address,uint256)
           handler: handleStreamCancelled
-        - event: TokensRecovered(indexed address,address,uint256)
+        - event: TokensRecovered(indexed address,address,uint256,address)
           handler: handleTokensRecovered
         - event: ETHRescued(indexed address,indexed address,uint256)
           handler: handleETHRescued

--- a/subgraph/tests/Stream.test.ts
+++ b/subgraph/tests/Stream.test.ts
@@ -104,9 +104,10 @@ describe("Stream", () => {
     const timestamp = BigInt.fromI32(1000);
     const tokenAddress = Address.fromString("0x0000000000000000000000000000000000000042");
     const amount = BigInt.fromI32(4321);
+    const to = Address.fromString("0x0000000000000000000000000000000000000043");
 
     handleTokensRecovered(
-      createTokensRecoveredEvent(txHash, logIndex, timestamp, streamAddress, payerAddress, tokenAddress, amount),
+      createTokensRecoveredEvent(txHash, logIndex, timestamp, streamAddress, payerAddress, tokenAddress, amount, to),
     );
 
     const tr = TokenRecovery.load(txHash.toHex() + "-" + logIndex.toString());
@@ -115,6 +116,7 @@ describe("Stream", () => {
     assert.stringEquals(tr!.stream.toHex(), streamAddress.toHex());
     assert.stringEquals(tr!.tokenAddress.toHex(), tokenAddress.toHex());
     assert.bigIntEquals(tr!.amount, amount);
+    assert.stringEquals(tr!.sentTo.toHex(), to.toHex());
   });
 
   test("Creates a new ETHRescue", () => {

--- a/subgraph/tests/utils.ts
+++ b/subgraph/tests/utils.ts
@@ -103,6 +103,7 @@ export function createTokensRecoveredEvent(
   payer: Address,
   tokenAddress: Address,
   amount: BigInt,
+  to: Address
 ): TokensRecovered {
   let newEvent = changetype<TokensRecovered>(newMockEvent());
 
@@ -115,6 +116,7 @@ export function createTokensRecoveredEvent(
   newEvent.parameters.push(new ethereum.EventParam("payer", ethereum.Value.fromAddress(payer)));
   newEvent.parameters.push(new ethereum.EventParam("tokenAddress", ethereum.Value.fromAddress(tokenAddress)));
   newEvent.parameters.push(new ethereum.EventParam("amount", ethereum.Value.fromUnsignedBigInt(amount)));
+  newEvent.parameters.push(new ethereum.EventParam("to", ethereum.Value.fromAddress(to)));
 
   return newEvent;
 }

--- a/test/Stream.t.sol
+++ b/test/Stream.t.sol
@@ -231,6 +231,20 @@ contract StreamWithdrawTest is StreamTest {
         s.withdrawAvailableBalance(STREAM_AMOUNT / 10);
         assertEq(token.balanceOf(recipient), STREAM_AMOUNT / 10);
     }
+
+    function test_withdrawAvailableBalance_revertsIfNotPayerOrRecipient() public {
+        token.mint(address(s), STREAM_AMOUNT);
+        vm.warp(startTime + DURATION / 10);
+
+        vm.expectRevert(abi.encodeWithSelector(Stream.CallerNotPayerOrRecipient.selector));
+        s.withdrawAvailableBalance(1);
+
+        vm.prank(recipient);
+        s.withdrawAvailableBalance(1);
+
+        vm.prank(payer);
+        s.withdrawAvailableBalance(1);
+    }
 }
 
 contract StreamBalanceOfTest is StreamTest {


### PR DESCRIPTION
Changes:

1. `recoverTokens`:
    1.1. added a `recoverTokens` function without an `amount` param. This is useful for when a DAO wants to cancel & recover in one proposal without knowing the exact amount in advance.
    1.2. added a `to` param to `recoverTokens`. This is useful for when a DAO wants to immediately send all the recovered tokens to a separate wallet/contracts. for Nouns this would be to the TokenBuyer contract.
2. Added `recipientAvailableBalance` and `withdrawAvailableBalance` functions which work for both active and cancelled streams. This make it easier for users/frontends to use without checking the state of the stream

    -> I don't like the functions names right now, but wanted to make the diff minimal. Maybe we should rename to:
            `recipientActiveBalance`, `recipientCancelBalance` & `recipientBalance` and
            `withdrawActiveBalance, `withdrawCancelBalance` & `withdraw`
